### PR TITLE
Bump main dependency for Ruby 3

### DIFF
--- a/tdd.gemspec
+++ b/tdd.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Tdd::VERSION
   gem.license = 'MIT'
-  
 
-  gem.add_runtime_dependency "main", "~> 5.0"
+
+  gem.add_runtime_dependency "main", "~> 6.0"
   gem.add_runtime_dependency "rb-fsevent", "~> 0.10"
   gem.add_runtime_dependency "ruby_gntp"
 end


### PR DESCRIPTION
Using current version (with main 5) with Ruby 3.1.2 produces this error:

```
FATAL -- : uninitialized constant Main::GetoptLong::FALSE

    @quiet = FALSE
             ^^^^^ (NameError)
```

